### PR TITLE
Added support for commits.

### DIFF
--- a/src/gator_yaml.py
+++ b/src/gator_yaml.py
@@ -9,7 +9,7 @@ class GatorYaml:
         self.spaces = spaces  # How many spaces is a tab
         self.tabs = -1  # Current tab level
         self.output = ""  # Init output
-        self.keywords = ["(pure)"]  # Any keywords to look for
+        self.keywords = ["(pure)", "commits"]  # Any keywords to look for
         self.indents = indent  # set indent for file path
 
     def dump(self, dic):
@@ -87,6 +87,11 @@ class GatorYaml:
     def is_keyword(self, key, value):
         """Output key and value if a keyword"""
         if key in self.keywords:
-            self.output += (" " * self.spaces) * self.tabs + str(key) + " " + str(value) + "\n"
+            if key == "commits":
+                self.output += (" " * self.spaces) * self.tabs \
+                               + "--" + str(key) + " " + str(value) + "\n"
+            else:
+                self.output += (" " * self.spaces) * self.tabs + str(key) \
+                               + " " + str(value) + "\n"
             return True
         return False

--- a/tests/test_gator_yaml.py
+++ b/tests/test_gator_yaml.py
@@ -77,7 +77,8 @@ def test_output_list_item(item, expected):
          "Continue?\n"),
         ({"break": True}, "break: True\n"),
         ({"listy!": ["item1", "Item2", True]}, "listy!:\n -item1\n -Item2\n -True\n"),
-        ({"(pure)": "pure output!"}, "(pure) pure output!\n")
+        ({"(pure)": "pure output!"}, "(pure) pure output!\n"),
+        ({"commits":10}, "--commits 10\n")
     ],
 )
 def test_dump(dic, expected):


### PR DESCRIPTION
# Feature: GatorYAML commit support

## Description

GatorYAML now supports the `--commits` flag.
To use these changes do the following:
Add a key of `commits` to the input dictionary with a integer value.

GatorYAML will output it as `--commits (value)`

### Type of Change

- [x] Feature
- [x] Bug fix
- [ ] Documentation

## Contributors

- @ullrichd21 

## Reminder

All GitHub Actions should be in a passing state before any pull request is merged.
