### PR TITLE
Feature gui

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,5 +71,9 @@ jobs:
           poetry env info
       - name: Install dependencies
         run: poetry install --no-interaction --no-ansi
+      - name: setup ${{ matrix.os }}
+        run: |
+          sudo apt install libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0
+          /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX
       - name: Execute tests
         run: poetry run task test

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,568 @@
+﻿[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-allow-list=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code. (This is an alternative name to extension-pkg-allow-list
+# for backward compatibility.)
+extension-pkg-whitelist=PyQt5
+
+# Return non-zero exit code if any of these messages/categories are detected,
+# even if score is above --fail-under value. Syntax same as enable. Messages
+# specified are enabled, while categories only check already-enabled messages.
+fail-on=
+
+# Specify a score threshold to be exceeded before program exits with error.
+fail-under=10.0
+
+# Files or directories to be skipped. They should be base names, not paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the ignore-list. The
+# regex matches against paths and can be in Posix or Windows format.
+ignore-paths=
+
+# Files or directories matching the regex patterns are skipped. The regex
+# matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Minimum Python version to use for version dependent checks. Will default to
+# the version used to run pylint.
+py-version=3.9
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-symbolic-message-instead
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'error', 'warning', 'refactor', and 'convention'
+# which contain the number of messages in each category, as well as 'statement'
+# which is the total number of statements analyzed. This score is used by the
+# global evaluation report (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit,argparse.parse_error
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+bad-names-rgxs=
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style.
+#class-attribute-rgx=
+
+# Naming style matching correct class constant names.
+class-const-naming-style=UPPER_CASE
+
+# Regular expression matching correct class constant names. Overrides class-
+# const-naming-style.
+#class-const-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+good-names-rgxs=
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+#variable-rgx=
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[LOGGING]
+
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+# Regular expression of note tags to take in consideration.
+#notes-rgx=
+
+
+[SIMILARITIES]
+
+# Comments are removed from the similarity computation
+ignore-comments=yes
+
+# Docstrings are removed from the similarity computation
+ignore-docstrings=yes
+
+# Imports are removed from the similarity computation
+ignore-imports=no
+
+# Signatures are removed from the similarity computation
+ignore-signatures=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it work,
+# install the 'python-enchant' package.
+spelling-dict=
+
+# List of comma separated words that should be considered directives if they
+# appear and the beginning of a comment and should not be checked.
+spelling-ignore-comment-directives=fmt: on,fmt: off,noqa:,noqa,nosec,isort:skip,mypy:
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
+
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
+check-str-concat-over-line-jumps=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# class is considered mixin if its name matches the mixin-class-rgx option.
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis). It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# Regex pattern to define which classes are considered mixins ignore-mixin-
+# members is set to 'yes'
+mixin-class-rgx=.*[Mm]ixin
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of names allowed to shadow builtins
+allowed-redefined-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[CLASSES]
+
+# Warn about protected attribute access inside special methods
+check-protected-access-in-special-methods=no
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[DESIGN]
+
+# List of regular expressions of class ancestor names to ignore when counting
+# public methods (see R0903)
+exclude-too-few-public-methods=
+
+# List of qualified class names to ignore when counting class parents (see
+# R0901)
+ignored-parents=
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=
+
+# Output a graph (.gv or any supported image format) of external dependencies
+# to the given file (report RP0402 must not be disabled).
+ext-import-graph=
+
+# Output a graph (.gv or any supported image format) of all (i.e. internal and
+# external) dependencies to the given file (report RP0402 must not be
+# disabled).
+import-graph=
+
+# Output a graph (.gv or any supported image format) of internal dependencies
+# to the given file (report RP0402 must not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "BaseException, Exception".
+overgeneral-exceptions=BaseException,
+                       Exception

--- a/poetry.lock
+++ b/poetry.lock
@@ -16,7 +16,7 @@ wrapt = ">=1.11,<1.14"
 name = "atomicwrites"
 version = "1.4.0"
 description = "Atomic file writes."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -24,7 +24,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 name = "attrs"
 version = "21.4.0"
 description = "Classes Without Boilerplate"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
@@ -89,7 +89,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 name = "iniconfig"
 version = "1.1.1"
 description = "iniconfig: brain-dead simple config-ini parsing"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -135,7 +135,7 @@ python-versions = ">=3.5"
 name = "packaging"
 version = "21.3"
 description = "Core utilities for Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -158,7 +158,7 @@ test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock 
 name = "pluggy"
 version = "1.0.0"
 description = "plugin and hook calling mechanisms for python"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -184,7 +184,7 @@ test = ["ipaddress", "mock", "unittest2", "enum34", "pywin32", "wmi"]
 name = "py"
 version = "1.11.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
@@ -209,7 +209,7 @@ typing-extensions = {version = ">=3.10.0", markers = "python_version < \"3.10\""
 name = "pyparsing"
 version = "3.0.6"
 description = "Python parsing module"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -248,7 +248,7 @@ python-versions = ">=3.5"
 name = "pytest"
 version = "6.2.5"
 description = "pytest: simple powerful testing with Python"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -280,6 +280,21 @@ pytest = ">=4.6"
 
 [package.extras]
 testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtualenv"]
+
+[[package]]
+name = "pytest-qt"
+version = "4.0.2"
+description = "pytest support for PyQt and PySide applications"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pytest = ">=3.0.0"
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+doc = ["sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "ruamel.yaml"
@@ -322,7 +337,7 @@ toml = ">=0.10.0,<0.11.0"
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
@@ -390,7 +405,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4.0"
-content-hash = "9182b7b781298b8823a67c7f0e3423e1c546699ac34f790fb936265caa2ae246"
+content-hash = "e0d2851e055bf94b8a8ca6ccb3fe19c9d143bc1df7f9345674348be9d8f9c789"
 
 [metadata.files]
 astroid = [
@@ -619,6 +634,10 @@ pytest = [
 pytest-cov = [
     {file = "pytest-cov-3.0.0.tar.gz", hash = "sha256:e7f0f5b1617d2210a2cabc266dfe2f4c75a8d32fb89eafb7ad9d06f6d076d470"},
     {file = "pytest_cov-3.0.0-py3-none-any.whl", hash = "sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6"},
+]
+pytest-qt = [
+    {file = "pytest-qt-4.0.2.tar.gz", hash = "sha256:dfc5240dec7eb43b76bcb5f9a87eecae6ef83592af49f3af5f1d5d093acaa93e"},
+    {file = "pytest_qt-4.0.2-py2.py3-none-any.whl", hash = "sha256:e03847ac02a890ccaac0fde1748855b9dce425aceba62005c6cfced6cf7d5456"},
 ]
 "ruamel.yaml" = [
     {file = "ruamel.yaml-0.17.20-py3-none-any.whl", hash = "sha256:810eef9c46523a3f77479c66267a4708255ebe806a2d540078408c2227f011af"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -69,6 +69,14 @@ tomli = {version = "*", optional = true, markers = "extra == \"toml\""}
 toml = ["tomli"]
 
 [[package]]
+name = "easyprocess"
+version = "1.1"
+description = "Easy to use Python subprocess interface."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "importlib-metadata"
 version = "4.10.1"
 description = "Read metadata from Python packages"
@@ -297,6 +305,29 @@ dev = ["pre-commit", "tox"]
 doc = ["sphinx", "sphinx-rtd-theme"]
 
 [[package]]
+name = "pytest-xvfb"
+version = "2.0.0"
+description = "A pytest plugin to run Xvfb for tests."
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+pytest = ">=2.8.1"
+pyvirtualdisplay = ">=1.3"
+
+[[package]]
+name = "pyvirtualdisplay"
+version = "2.2"
+description = "python wrapper for Xvfb, Xephyr and Xvnc"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+EasyProcess = "*"
+
+[[package]]
 name = "ruamel.yaml"
 version = "0.17.20"
 description = "ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order"
@@ -405,7 +436,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4.0"
-content-hash = "e0d2851e055bf94b8a8ca6ccb3fe19c9d143bc1df7f9345674348be9d8f9c789"
+content-hash = "087f738e7f8167984e00b3a1273e76eb0076b1816c6134be396056c4701b3ffa"
 
 [metadata.files]
 astroid = [
@@ -473,6 +504,10 @@ coverage = [
     {file = "coverage-6.3-cp39-cp39-win_amd64.whl", hash = "sha256:e67ccd53da5958ea1ec833a160b96357f90859c220a00150de011b787c27b98d"},
     {file = "coverage-6.3-pp36.pp37.pp38-none-any.whl", hash = "sha256:27ac7cb84538e278e07569ceaaa6f807a029dc194b1c819a9820b9bb5dbf63ab"},
     {file = "coverage-6.3.tar.gz", hash = "sha256:987a84ff98a309994ca77ed3cc4b92424f824278e48e4bf7d1bb79a63cfe2099"},
+]
+easyprocess = [
+    {file = "EasyProcess-1.1-py3-none-any.whl", hash = "sha256:82eed523a0a5eb12a81fa4eacd9f342caeb3f900eb4b798740e6696ad07e63f9"},
+    {file = "EasyProcess-1.1.tar.gz", hash = "sha256:885898302a57aab948973e8b5d32a4229392b9fb2d986ab1d4ffd590e5ba90ec"},
 ]
 importlib-metadata = [
     {file = "importlib_metadata-4.10.1-py3-none-any.whl", hash = "sha256:899e2a40a8c4a1aec681feef45733de8a6c58f3f6a0dbed2eb6574b4387a77b6"},
@@ -638,6 +673,14 @@ pytest-cov = [
 pytest-qt = [
     {file = "pytest-qt-4.0.2.tar.gz", hash = "sha256:dfc5240dec7eb43b76bcb5f9a87eecae6ef83592af49f3af5f1d5d093acaa93e"},
     {file = "pytest_qt-4.0.2-py2.py3-none-any.whl", hash = "sha256:e03847ac02a890ccaac0fde1748855b9dce425aceba62005c6cfced6cf7d5456"},
+]
+pytest-xvfb = [
+    {file = "pytest-xvfb-2.0.0.tar.gz", hash = "sha256:c4ba642de05499940db7f65ee111621939be513e3e75c3da9156b7235e2ed8cf"},
+    {file = "pytest_xvfb-2.0.0-py3-none-any.whl", hash = "sha256:6d21b46f099c06d6b8b200e73341da3adb73d67e9139c55d617930881779360b"},
+]
+pyvirtualdisplay = [
+    {file = "PyVirtualDisplay-2.2-py3-none-any.whl", hash = "sha256:3dd8f63d32a134c07c2433f6931e9877172a99a33757f0e5cd146612e1c6380d"},
+    {file = "PyVirtualDisplay-2.2.tar.gz", hash = "sha256:3ecda6b183b03ba65dcfdf0019809722480d7b7e10eea6e3a40bf1ba3146bab7"},
 ]
 "ruamel.yaml" = [
     {file = "ruamel.yaml-0.17.20-py3-none-any.whl", hash = "sha256:810eef9c46523a3f77479c66267a4708255ebe806a2d540078408c2227f011af"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -56,11 +56,11 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "coverage"
-version = "6.2"
+version = "6.3"
 description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 tomli = {version = "*", optional = true, markers = "extra == \"toml\""}
@@ -217,6 +217,34 @@ python-versions = ">=3.6"
 diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
+name = "pyqt5"
+version = "5.15.6"
+description = "Python bindings for the Qt cross platform application toolkit"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+PyQt5-Qt5 = ">=5.15.2"
+PyQt5-sip = ">=12.8,<13"
+
+[[package]]
+name = "pyqt5-qt5"
+version = "5.15.2"
+description = "The subset of a Qt installation needed by PyQt5."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "pyqt5-sip"
+version = "12.9.0"
+description = "The sip module support for PyQt5"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
 name = "pytest"
 version = "6.2.5"
 description = "pytest: simple powerful testing with Python"
@@ -362,7 +390,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4.0"
-content-hash = "ff82394f0e808fe004a321e6a679f9e28d2a22075fc8283dc717e07295d079f6"
+content-hash = "9182b7b781298b8823a67c7f0e3423e1c546699ac34f790fb936265caa2ae246"
 
 [metadata.files]
 astroid = [
@@ -386,53 +414,50 @@ colorama = [
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 coverage = [
-    {file = "coverage-6.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6dbc1536e105adda7a6312c778f15aaabe583b0e9a0b0a324990334fd458c94b"},
-    {file = "coverage-6.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:174cf9b4bef0db2e8244f82059a5a72bd47e1d40e71c68ab055425172b16b7d0"},
-    {file = "coverage-6.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:92b8c845527eae547a2a6617d336adc56394050c3ed8a6918683646328fbb6da"},
-    {file = "coverage-6.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c7912d1526299cb04c88288e148c6c87c0df600eca76efd99d84396cfe00ef1d"},
-    {file = "coverage-6.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:d5d2033d5db1d58ae2d62f095e1aefb6988af65b4b12cb8987af409587cc0739"},
-    {file = "coverage-6.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:3feac4084291642165c3a0d9eaebedf19ffa505016c4d3db15bfe235718d4971"},
-    {file = "coverage-6.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:276651978c94a8c5672ea60a2656e95a3cce2a3f31e9fb2d5ebd4c215d095840"},
-    {file = "coverage-6.2-cp310-cp310-win32.whl", hash = "sha256:f506af4f27def639ba45789fa6fde45f9a217da0be05f8910458e4557eed020c"},
-    {file = "coverage-6.2-cp310-cp310-win_amd64.whl", hash = "sha256:3f7c17209eef285c86f819ff04a6d4cbee9b33ef05cbcaae4c0b4e8e06b3ec8f"},
-    {file = "coverage-6.2-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:13362889b2d46e8d9f97c421539c97c963e34031ab0cb89e8ca83a10cc71ac76"},
-    {file = "coverage-6.2-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:22e60a3ca5acba37d1d4a2ee66e051f5b0e1b9ac950b5b0cf4aa5366eda41d47"},
-    {file = "coverage-6.2-cp311-cp311-win_amd64.whl", hash = "sha256:b637c57fdb8be84e91fac60d9325a66a5981f8086c954ea2772efe28425eaf64"},
-    {file = "coverage-6.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f467bbb837691ab5a8ca359199d3429a11a01e6dfb3d9dcc676dc035ca93c0a9"},
-    {file = "coverage-6.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2641f803ee9f95b1f387f3e8f3bf28d83d9b69a39e9911e5bfee832bea75240d"},
-    {file = "coverage-6.2-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:1219d760ccfafc03c0822ae2e06e3b1248a8e6d1a70928966bafc6838d3c9e48"},
-    {file = "coverage-6.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:9a2b5b52be0a8626fcbffd7e689781bf8c2ac01613e77feda93d96184949a98e"},
-    {file = "coverage-6.2-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:8e2c35a4c1f269704e90888e56f794e2d9c0262fb0c1b1c8c4ee44d9b9e77b5d"},
-    {file = "coverage-6.2-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:5d6b09c972ce9200264c35a1d53d43ca55ef61836d9ec60f0d44273a31aa9f17"},
-    {file = "coverage-6.2-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:e3db840a4dee542e37e09f30859f1612da90e1c5239a6a2498c473183a50e781"},
-    {file = "coverage-6.2-cp36-cp36m-win32.whl", hash = "sha256:4e547122ca2d244f7c090fe3f4b5a5861255ff66b7ab6d98f44a0222aaf8671a"},
-    {file = "coverage-6.2-cp36-cp36m-win_amd64.whl", hash = "sha256:01774a2c2c729619760320270e42cd9e797427ecfddd32c2a7b639cdc481f3c0"},
-    {file = "coverage-6.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fb8b8ee99b3fffe4fd86f4c81b35a6bf7e4462cba019997af2fe679365db0c49"},
-    {file = "coverage-6.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:619346d57c7126ae49ac95b11b0dc8e36c1dd49d148477461bb66c8cf13bb521"},
-    {file = "coverage-6.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0a7726f74ff63f41e95ed3a89fef002916c828bb5fcae83b505b49d81a066884"},
-    {file = "coverage-6.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:cfd9386c1d6f13b37e05a91a8583e802f8059bebfccde61a418c5808dea6bbfa"},
-    {file = "coverage-6.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:17e6c11038d4ed6e8af1407d9e89a2904d573be29d51515f14262d7f10ef0a64"},
-    {file = "coverage-6.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:c254b03032d5a06de049ce8bca8338a5185f07fb76600afff3c161e053d88617"},
-    {file = "coverage-6.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:dca38a21e4423f3edb821292e97cec7ad38086f84313462098568baedf4331f8"},
-    {file = "coverage-6.2-cp37-cp37m-win32.whl", hash = "sha256:600617008aa82032ddeace2535626d1bc212dfff32b43989539deda63b3f36e4"},
-    {file = "coverage-6.2-cp37-cp37m-win_amd64.whl", hash = "sha256:bf154ba7ee2fd613eb541c2bc03d3d9ac667080a737449d1a3fb342740eb1a74"},
-    {file = "coverage-6.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f9afb5b746781fc2abce26193d1c817b7eb0e11459510fba65d2bd77fe161d9e"},
-    {file = "coverage-6.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:edcada2e24ed68f019175c2b2af2a8b481d3d084798b8c20d15d34f5c733fa58"},
-    {file = "coverage-6.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:a9c8c4283e17690ff1a7427123ffb428ad6a52ed720d550e299e8291e33184dc"},
-    {file = "coverage-6.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f614fc9956d76d8a88a88bb41ddc12709caa755666f580af3a688899721efecd"},
-    {file = "coverage-6.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:9365ed5cce5d0cf2c10afc6add145c5037d3148585b8ae0e77cc1efdd6aa2953"},
-    {file = "coverage-6.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:8bdfe9ff3a4ea37d17f172ac0dff1e1c383aec17a636b9b35906babc9f0f5475"},
-    {file = "coverage-6.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:63c424e6f5b4ab1cf1e23a43b12f542b0ec2e54f99ec9f11b75382152981df57"},
-    {file = "coverage-6.2-cp38-cp38-win32.whl", hash = "sha256:49dbff64961bc9bdd2289a2bda6a3a5a331964ba5497f694e2cbd540d656dc1c"},
-    {file = "coverage-6.2-cp38-cp38-win_amd64.whl", hash = "sha256:9a29311bd6429be317c1f3fe4bc06c4c5ee45e2fa61b2a19d4d1d6111cb94af2"},
-    {file = "coverage-6.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:03b20e52b7d31be571c9c06b74746746d4eb82fc260e594dc662ed48145e9efd"},
-    {file = "coverage-6.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:215f8afcc02a24c2d9a10d3790b21054b58d71f4b3c6f055d4bb1b15cecce685"},
-    {file = "coverage-6.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:a4bdeb0a52d1d04123b41d90a4390b096f3ef38eee35e11f0b22c2d031222c6c"},
-    {file = "coverage-6.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c332d8f8d448ded473b97fefe4a0983265af21917d8b0cdcb8bb06b2afe632c3"},
-    {file = "coverage-6.2-cp39-cp39-win32.whl", hash = "sha256:6e1394d24d5938e561fbeaa0cd3d356207579c28bd1792f25a068743f2d5b282"},
-    {file = "coverage-6.2-cp39-cp39-win_amd64.whl", hash = "sha256:86f2e78b1eff847609b1ca8050c9e1fa3bd44ce755b2ec30e70f2d3ba3844644"},
-    {file = "coverage-6.2-pp36.pp37.pp38-none-any.whl", hash = "sha256:5829192582c0ec8ca4a2532407bc14c2f338d9878a10442f5d03804a95fac9de"},
-    {file = "coverage-6.2.tar.gz", hash = "sha256:e2cad8093172b7d1595b4ad66f24270808658e11acf43a8f95b41276162eb5b8"},
+    {file = "coverage-6.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e8071e7d9ba9f457fc674afc3de054450be2c9b195c470147fbbc082468d8ff7"},
+    {file = "coverage-6.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:86c91c511853dfda81c2cf2360502cb72783f4b7cebabef27869f00cbe1db07d"},
+    {file = "coverage-6.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3c4ce3b647bd1792d4394f5690d9df6dc035b00bcdbc5595099c01282a59ae01"},
+    {file = "coverage-6.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2a491e159294d756e7fc8462f98175e2d2225e4dbe062cca7d3e0d5a75ba6260"},
+    {file = "coverage-6.3-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d008e0f67ac800b0ca04d7914b8501312c8c6c00ad8c7ba17754609fae1231a"},
+    {file = "coverage-6.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4578728c36de2801c1deb1c6b760d31883e62e33f33c7ba8f982e609dc95167d"},
+    {file = "coverage-6.3-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:7ee317486593193e066fc5e98ac0ce712178c21529a85c07b7cb978171f25d53"},
+    {file = "coverage-6.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:2bc85664b06ba42d14bb74d6ddf19d8bfc520cb660561d2d9ce5786ae72f71b5"},
+    {file = "coverage-6.3-cp310-cp310-win32.whl", hash = "sha256:27a94db5dc098c25048b0aca155f5fac674f2cf1b1736c5272ba28ead2fc267e"},
+    {file = "coverage-6.3-cp310-cp310-win_amd64.whl", hash = "sha256:bde4aeabc0d1b2e52c4036c54440b1ad05beeca8113f47aceb4998bb7471e2c2"},
+    {file = "coverage-6.3-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:509c68c3e2015022aeda03b003dd68fa19987cdcf64e9d4edc98db41cfc45d30"},
+    {file = "coverage-6.3-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:e4ff163602c5c77e7bb4ea81ba5d3b793b4419f8acd296aae149370902cf4e92"},
+    {file = "coverage-6.3-cp311-cp311-win_amd64.whl", hash = "sha256:d1675db48490e5fa0b300f6329ecb8a9a37c29b9ab64fa9c964d34111788ca2d"},
+    {file = "coverage-6.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:7eed8459a2b81848cafb3280b39d7d49950d5f98e403677941c752e7e7ee47cb"},
+    {file = "coverage-6.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1b4285fde5286b946835a1a53bba3ad41ef74285ba9e8013e14b5ea93deaeafc"},
+    {file = "coverage-6.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a4748349734110fd32d46ff8897b561e6300d8989a494ad5a0a2e4f0ca974fc7"},
+    {file = "coverage-6.3-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:823f9325283dc9565ba0aa2d240471a93ca8999861779b2b6c7aded45b58ee0f"},
+    {file = "coverage-6.3-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:fff16a30fdf57b214778eff86391301c4509e327a65b877862f7c929f10a4253"},
+    {file = "coverage-6.3-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:da1a428bdbe71f9a8c270c7baab29e9552ac9d0e0cba5e7e9a4c9ee6465d258d"},
+    {file = "coverage-6.3-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:7d82c610a2e10372e128023c5baf9ce3d270f3029fe7274ff5bc2897c68f1318"},
+    {file = "coverage-6.3-cp37-cp37m-win32.whl", hash = "sha256:11e61c5548ecf74ea1f8b059730b049871f0e32b74f88bd0d670c20c819ad749"},
+    {file = "coverage-6.3-cp37-cp37m-win_amd64.whl", hash = "sha256:8e0c3525b1a182c8ffc9bca7e56b521e0c2b8b3e82f033c8e16d6d721f1b54d6"},
+    {file = "coverage-6.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:a189036c50dcd56100746139a459f0d27540fef95b09aba03e786540b8feaa5f"},
+    {file = "coverage-6.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:32168001f33025fd756884d56d01adebb34e6c8c0b3395ca8584cdcee9c7c9d2"},
+    {file = "coverage-6.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5d79c9af3f410a2b5acad91258b4ae179ee9c83897eb9de69151b179b0227f5"},
+    {file = "coverage-6.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:85c5fc9029043cf8b07f73fbb0a7ab6d3b717510c3b5642b77058ea55d7cacde"},
+    {file = "coverage-6.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a7596aa2f2b8fa5604129cfc9a27ad9beec0a96f18078cb424d029fdd707468d"},
+    {file = "coverage-6.3-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:ce443a3e6df90d692c38762f108fc4c88314bf477689f04de76b3f252e7a351c"},
+    {file = "coverage-6.3-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:012157499ec4f135fc36cd2177e3d1a1840af9b236cbe80e9a5ccfc83d912a69"},
+    {file = "coverage-6.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:0a34d313105cdd0d3644c56df2d743fe467270d6ab93b5d4a347eb9fec8924d6"},
+    {file = "coverage-6.3-cp38-cp38-win32.whl", hash = "sha256:6e78b1e25e5c5695dea012be473e442f7094d066925604be20b30713dbd47f89"},
+    {file = "coverage-6.3-cp38-cp38-win_amd64.whl", hash = "sha256:433b99f7b0613bdcdc0b00cc3d39ed6d756797e3b078d2c43f8a38288520aec6"},
+    {file = "coverage-6.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9ed3244b415725f08ca3bdf02ed681089fd95e9465099a21c8e2d9c5d6ca2606"},
+    {file = "coverage-6.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ab4fc4b866b279740e0d917402f0e9a08683e002f43fa408e9655818ed392196"},
+    {file = "coverage-6.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c8582e9280f8d0f38114fe95a92ae8d0790b56b099d728cc4f8a2e14b1c4a18c"},
+    {file = "coverage-6.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c72bb4679283c6737f452eeb9b2a0e570acaef2197ad255fb20162adc80bea76"},
+    {file = "coverage-6.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca29c352389ea27a24c79acd117abdd8a865c6eb01576b6f0990cd9a4e9c9f48"},
+    {file = "coverage-6.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:152cc2624381df4e4e604e21bd8e95eb8059535f7b768c1fb8b8ae0b26f47ab0"},
+    {file = "coverage-6.3-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:51372e24b1f7143ee2df6b45cff6a721f3abe93b1e506196f3ffa4155c2497f7"},
+    {file = "coverage-6.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:72d9d186508325a456475dd05b1756f9a204c7086b07fffb227ef8cee03b1dc2"},
+    {file = "coverage-6.3-cp39-cp39-win32.whl", hash = "sha256:649df3641eb351cdfd0d5533c92fc9df507b6b2bf48a7ef8c71ab63cbc7b5c3c"},
+    {file = "coverage-6.3-cp39-cp39-win_amd64.whl", hash = "sha256:e67ccd53da5958ea1ec833a160b96357f90859c220a00150de011b787c27b98d"},
+    {file = "coverage-6.3-pp36.pp37.pp38-none-any.whl", hash = "sha256:27ac7cb84538e278e07569ceaaa6f807a029dc194b1c819a9820b9bb5dbf63ab"},
+    {file = "coverage-6.3.tar.gz", hash = "sha256:987a84ff98a309994ca77ed3cc4b92424f824278e48e4bf7d1bb79a63cfe2099"},
 ]
 importlib-metadata = [
     {file = "importlib_metadata-4.10.1-py3-none-any.whl", hash = "sha256:899e2a40a8c4a1aec681feef45733de8a6c58f3f6a0dbed2eb6574b4387a77b6"},
@@ -550,6 +575,42 @@ pylint = [
 pyparsing = [
     {file = "pyparsing-3.0.6-py3-none-any.whl", hash = "sha256:04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4"},
     {file = "pyparsing-3.0.6.tar.gz", hash = "sha256:d9bdec0013ef1eb5a84ab39a3b3868911598afa494f5faa038647101504e2b81"},
+]
+pyqt5 = [
+    {file = "PyQt5-5.15.6-cp36-abi3-macosx_10_13_x86_64.whl", hash = "sha256:33ced1c876f6a26e7899615a5a4efef2167c263488837c7beed023a64cebd051"},
+    {file = "PyQt5-5.15.6-cp36-abi3-manylinux1_x86_64.whl", hash = "sha256:9d6efad0377aa78bf081a20ac752ce86096ded18f04c592d98f5b92dc879ad0a"},
+    {file = "PyQt5-5.15.6-cp36-abi3-win32.whl", hash = "sha256:9d2dcdaf82263ae56023410a7af15d1fd746c8e361733a7d0d1bd1f004ec2793"},
+    {file = "PyQt5-5.15.6-cp36-abi3-win_amd64.whl", hash = "sha256:f411ecda52e488e1d3c5cce7563e1b2ca9cf0b7531e3c25b03d9a7e56e07e7fc"},
+    {file = "PyQt5-5.15.6.tar.gz", hash = "sha256:80343bcab95ffba619f2ed2467fd828ffeb0a251ad7225be5fc06dcc333af452"},
+]
+pyqt5-qt5 = [
+    {file = "PyQt5_Qt5-5.15.2-py3-none-macosx_10_13_intel.whl", hash = "sha256:76980cd3d7ae87e3c7a33bfebfaee84448fd650bad6840471d6cae199b56e154"},
+    {file = "PyQt5_Qt5-5.15.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:1988f364ec8caf87a6ee5d5a3a5210d57539988bf8e84714c7d60972692e2f4a"},
+    {file = "PyQt5_Qt5-5.15.2-py3-none-win32.whl", hash = "sha256:9cc7a768b1921f4b982ebc00a318ccb38578e44e45316c7a4a850e953e1dd327"},
+    {file = "PyQt5_Qt5-5.15.2-py3-none-win_amd64.whl", hash = "sha256:750b78e4dba6bdf1607febedc08738e318ea09e9b10aea9ff0d73073f11f6962"},
+]
+pyqt5-sip = [
+    {file = "PyQt5_sip-12.9.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:6d5bca2fc222d58e8093ee8a81a6e3437067bb22bc3f86d06ec8be721e15e90a"},
+    {file = "PyQt5_sip-12.9.0-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:d59af63120d1475b2bf94fe8062610720a9be1e8940ea146c7f42bb449d49067"},
+    {file = "PyQt5_sip-12.9.0-cp310-cp310-win32.whl", hash = "sha256:0fc9aefacf502696710b36cdc9fa2a61487f55ee883dbcf2c2a6477e261546f7"},
+    {file = "PyQt5_sip-12.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:485972daff2fb0311013f471998f8ec8262ea381bded244f9d14edaad5f54271"},
+    {file = "PyQt5_sip-12.9.0-cp36-cp36m-macosx_10_6_intel.whl", hash = "sha256:d85002238b5180bce4b245c13d6face848faa1a7a9e5c6e292025004f2fd619a"},
+    {file = "PyQt5_sip-12.9.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:83c3220b1ca36eb8623ba2eb3766637b19eb0ce9f42336ad8253656d32750c0a"},
+    {file = "PyQt5_sip-12.9.0-cp36-cp36m-win32.whl", hash = "sha256:d8b2bdff7bbf45bc975c113a03b14fd669dc0c73e1327f02706666a7dd51a197"},
+    {file = "PyQt5_sip-12.9.0-cp36-cp36m-win_amd64.whl", hash = "sha256:69a3ad4259172e2b1aa9060de211efac39ddd734a517b1924d9c6c0cc4f55f96"},
+    {file = "PyQt5_sip-12.9.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:42274a501ab4806d2c31659170db14c282b8313d2255458064666d9e70d96206"},
+    {file = "PyQt5_sip-12.9.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:6a8701892a01a5a2a4720872361197cc80fdd5f49c8482d488ddf38c9c84f055"},
+    {file = "PyQt5_sip-12.9.0-cp37-cp37m-win32.whl", hash = "sha256:ac57d796c78117eb39edd1d1d1aea90354651efac9d3590aac67fa4983f99f1f"},
+    {file = "PyQt5_sip-12.9.0-cp37-cp37m-win_amd64.whl", hash = "sha256:4347bd81d30c8e3181e553b3734f91658cfbdd8f1a19f254777f906870974e6d"},
+    {file = "PyQt5_sip-12.9.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:c446971c360a0a1030282a69375a08c78e8a61d568bfd6dab3dcc5cf8817f644"},
+    {file = "PyQt5_sip-12.9.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:fc43f2d7c438517ee33e929e8ae77132749c15909afab6aeece5fcf4147ffdb5"},
+    {file = "PyQt5_sip-12.9.0-cp38-cp38-win32.whl", hash = "sha256:055581c6fed44ba4302b70eeb82e979ff70400037358908f251cd85cbb3dbd93"},
+    {file = "PyQt5_sip-12.9.0-cp38-cp38-win_amd64.whl", hash = "sha256:c5216403d4d8d857ec4a61f631d3945e44fa248aa2415e9ee9369ab7c8a4d0c7"},
+    {file = "PyQt5_sip-12.9.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a25b9843c7da6a1608f310879c38e6434331aab1dc2fe6cb65c14f1ecf33780e"},
+    {file = "PyQt5_sip-12.9.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:dd05c768c2b55ffe56a9d49ce6cc77cdf3d53dbfad935258a9e347cbfd9a5850"},
+    {file = "PyQt5_sip-12.9.0-cp39-cp39-win32.whl", hash = "sha256:4f8e05fe01d54275877c59018d8e82dcdd0bc5696053a8b830eecea3ce806121"},
+    {file = "PyQt5_sip-12.9.0-cp39-cp39-win_amd64.whl", hash = "sha256:b09f4cd36a4831229fb77c424d89635fa937d97765ec90685e2f257e56a2685a"},
+    {file = "PyQt5_sip-12.9.0.tar.gz", hash = "sha256:d3e4489d7c2b0ece9d203ae66e573939f7f60d4d29e089c9f11daa17cfeaae32"},
 ]
 pytest = [
     {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ license = "MIT"
 python = ">=3.7,<4.0"
 typer = "^0.4.0"
 "ruamel.yaml" = "^0.17.20"
+PyQt5 = "^5.15.6"
 
 [tool.poetry.dev-dependencies]
 taskipy = "^1.9.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,8 @@ pytest-cov = "^3.0.0"
 pylint = "^2.12.2"
 
 [tool.taskipy.tasks]
-test = "pytest --cov-report term-missing --cov-fail-under=70  --cov-branch --cov=src tests/"
-lint = "pylint src/ tests/"
+test = "pytest --cov-report term-missing --cov-fail-under=70  --cov-branch --cov=src tests/ --ignore src/gui/"
+lint = "pylint src/ tests/ src/gui/"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ python = ">=3.7,<4.0"
 typer = "^0.4.0"
 "ruamel.yaml" = "^0.17.20"
 PyQt5 = "^5.15.6"
+pytest-qt = "^4.0.2"
 
 [tool.poetry.dev-dependencies]
 taskipy = "^1.9.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ typer = "^0.4.0"
 "ruamel.yaml" = "^0.17.20"
 PyQt5 = "^5.15.6"
 pytest-qt = "^4.0.2"
+pytest-xvfb = "^2.0.0"
 
 [tool.poetry.dev-dependencies]
 taskipy = "^1.9.0"

--- a/src/gui/check_file.py
+++ b/src/gui/check_file.py
@@ -1,15 +1,19 @@
-from PyQt5 import QtGui
-from PyQt5.QtCore import *
-from PyQt5.QtGui import *
-from PyQt5.QtWidgets import *
+"""Checked File widgets"""
+
 import os
+from PyQt5.QtWidgets import QWidget, \
+    QVBoxLayout, QLabel, \
+    QHBoxLayout, QLineEdit, QPushButton, \
+    QPlainTextEdit, QFrame, \
+    QFileDialog
 
 
 class CheckFile(QWidget):
-    def __init__(self, parent=None):
-        super(QWidget, self).__init__(parent=None)
+    """QWidget class for a checked file"""
 
-        # self.box = QGroupBox()
+    def __init__(self, parent=None):
+        """Init QWidget parent and the widgets that make up a checked file widget"""
+        super().__init__(parent)
         self.outer_lay = QVBoxLayout()
 
         self.file = None
@@ -20,7 +24,7 @@ class CheckFile(QWidget):
         self.check_label = QLabel("File ")
         self.path_text = QLineEdit()
         self.path_button = QPushButton("Open",
-                                       clicked=lambda: self.get_path_from_file(self.path_text, self.path_button))
+                                       clicked=lambda: self.get_path_from_file(self.path_text))
         self.file_params = QPlainTextEdit()
 
         # Add widgets to hbox layout
@@ -31,17 +35,7 @@ class CheckFile(QWidget):
         self.outer_lay.addLayout(lay)
         self.outer_lay.addWidget(self.file_params)
 
-
-        # ----File Params----#
-
-        # self.add_param_button = QPushButton("Add New Check", clicked=lambda: self.add_param())
-
-        # self.outer_lay.addWidget(self.add_param_button)
-
-
-
-        # self.box.setLayout(self.outer_lay)
-
+        # Horizontal line separator
         self.frame = QFrame()
         self.frame.setFrameShape(QFrame.HLine)
         self.frame.setFrameShadow(QFrame.Sunken)
@@ -50,31 +44,16 @@ class CheckFile(QWidget):
 
         self.setLayout(self.outer_lay)
 
-    def get_path_from_file(self, targetText, targetButton):
+    def get_path_from_file(self, target_text):
+        """Opens a file dialog to select a new file.
+        Sets self.file to the file name and sets the tab text."""
         self.file = QFileDialog.getOpenFileName(self, 'OpenFile')[0]
-        targetText.setText(self.file)
+        target_text.setText(self.file)
         tabs = self.parentWidget().parentWidget()
         tabs.setTabText(tabs.currentIndex(), os.path.basename(self.file))
 
     def get_data(self):
+        """Gets all the data of the checked files and returns their file paths and params."""
         if self.file is None:
             self.file = self.path_text.text()
         return self.file, self.file_params.toPlainText().split()
-
-    def add_param(self):
-        self.outer_lay.insertWidget(self.outer_lay.count() - 1, Param(self.outer_lay.count() - 1))
-
-
-class Param(QWidget):
-    def __init__(self, check_num, parent=None):
-        super(QWidget, self).__init__(parent)
-
-        self.label = QLabel("Check " + str(check_num))
-        self.line = QLineEdit()
-
-        lay = QHBoxLayout()
-        lay.addWidget(self.label)
-        lay.addWidget(self.line)
-
-        self.setLayout(lay)
-

--- a/src/gui/check_file.py
+++ b/src/gui/check_file.py
@@ -1,0 +1,80 @@
+from PyQt5 import QtGui
+from PyQt5.QtCore import *
+from PyQt5.QtGui import *
+from PyQt5.QtWidgets import *
+import os
+
+
+class CheckFile(QWidget):
+    def __init__(self, parent=None):
+        super(QWidget, self).__init__(parent=None)
+
+        # self.box = QGroupBox()
+        self.outer_lay = QVBoxLayout()
+
+        self.file = None
+
+        # ----File Browser----#
+        # Hbox Layout
+        lay = QHBoxLayout()
+        self.check_label = QLabel("File ")
+        self.path_text = QLineEdit()
+        self.path_button = QPushButton("Open",
+                                       clicked=lambda: self.get_path_from_file(self.path_text, self.path_button))
+        self.file_params = QPlainTextEdit()
+
+        # Add widgets to hbox layout
+        lay.addWidget(self.check_label)
+        lay.addWidget(self.path_text)
+        lay.addWidget(self.path_button)
+
+        self.outer_lay.addLayout(lay)
+        self.outer_lay.addWidget(self.file_params)
+
+
+        # ----File Params----#
+
+        # self.add_param_button = QPushButton("Add New Check", clicked=lambda: self.add_param())
+
+        # self.outer_lay.addWidget(self.add_param_button)
+
+
+
+        # self.box.setLayout(self.outer_lay)
+
+        self.frame = QFrame()
+        self.frame.setFrameShape(QFrame.HLine)
+        self.frame.setFrameShadow(QFrame.Sunken)
+
+        self.outer_lay.addWidget(self.frame)
+
+        self.setLayout(self.outer_lay)
+
+    def get_path_from_file(self, targetText, targetButton):
+        self.file = QFileDialog.getOpenFileName(self, 'OpenFile')[0]
+        targetText.setText(self.file)
+        tabs = self.parentWidget().parentWidget()
+        tabs.setTabText(tabs.currentIndex(), os.path.basename(self.file))
+
+    def get_data(self):
+        if self.file is None:
+            self.file = self.path_text.text()
+        return self.file, self.file_params.toPlainText().split()
+
+    def add_param(self):
+        self.outer_lay.insertWidget(self.outer_lay.count() - 1, Param(self.outer_lay.count() - 1))
+
+
+class Param(QWidget):
+    def __init__(self, check_num, parent=None):
+        super(QWidget, self).__init__(parent)
+
+        self.label = QLabel("Check " + str(check_num))
+        self.line = QLineEdit()
+
+        lay = QHBoxLayout()
+        lay.addWidget(self.label)
+        lay.addWidget(self.line)
+
+        self.setLayout(lay)
+

--- a/src/gui/form.py
+++ b/src/gui/form.py
@@ -1,0 +1,132 @@
+from PyQt5 import QtGui
+from PyQt5.QtCore import *
+from PyQt5.QtGui import *
+from PyQt5.QtWidgets import *
+
+from gui.check_file import CheckFile
+
+
+class Form(QTabWidget):
+    def __init__(self, parent=None):
+        super(QTabWidget, self).__init__(parent)
+
+        # Create tabs
+        self.basic = QWidget()
+        self.advanced = QWidget()
+
+        # Add form to tabs
+        self.addTab(self.basic, "Basic")
+        self.addTab(self.advanced, "Advanced")
+        self.basic_tab()
+        self.advanced_tab()
+
+    def basic_tab(self):
+        # Create a QFormLayout instance
+        form_layout = QFormLayout()
+
+        # Add widgets to the form
+        self.fast_fail = QCheckBox()
+        self.break_fail = QCheckBox()
+        self.generate_readme = QCheckBox()
+
+        self.grader_version = QLineEdit("v0.2.0")
+
+        self.assignment_name = QLineEdit("Default")
+
+        form_layout.addRow("Fast Fail:", self.fast_fail)
+        form_layout.addRow("Break:", self.break_fail)
+        form_layout.addRow("Generate ReadMe:", self.generate_readme)
+        form_layout.addRow("GatorGrader Version:", self.grader_version)
+        form_layout.addRow("Assignment Name:", self.assignment_name)
+
+        # Create VBox for group
+        group_lay = QVBoxLayout()
+
+        self.tabs = QTabWidget()
+        self.tabs.setTabsClosable(True)
+        self.tabs.tabCloseRequested.connect(lambda index: self.tabs.removeTab(index))
+
+        # Checked Files Controls
+        # Create add file button
+        add_file_button = QPushButton("Add New Checked File", clicked=lambda: self.add_checked_file())
+
+        # Add button to layout
+        group_lay.addWidget(add_file_button)
+
+        # group.setLayout(group_lay)
+        form_layout.addRow(self.tabs)
+        form_layout.addRow(group_lay)
+
+        self.setTabText(0, "Basic")
+        self.basic.setLayout(form_layout)
+
+    def advanced_tab(self):
+        # Create a QFormLayout instance
+        form_layout = QFormLayout()
+
+        # Add widgets to the form
+
+        # ---Indent Size---#
+        self.indent_size = QSpinBox()
+        self.indent_size.setValue(4)
+        self.indent_size.setMinimum(1)
+
+        form_layout.addRow("Indent Size:", self.indent_size)
+
+        # ---Startup Script---#
+
+        # Hbox Layout
+        self.lay = QHBoxLayout()
+        self.startup_script_text = QLineEdit()
+        self.startup_script_button = QPushButton("Open",
+                                                 clicked=lambda: self.get_path_from_file(self.startup_script_text,
+                                                                                         self.startup_script_button))
+
+        # connect button to file dialog
+        # self.startup_script_button.clicked.connect()
+
+        # Add widgets to hbox layout
+        self.lay.addWidget(self.startup_script_text)
+        self.lay.addWidget(self.startup_script_button)
+
+        form_layout.addRow("Startup Script:", self.lay)
+
+        self.description_input2 = QPlainTextEdit()
+
+        # submit_button = QPushButton("Submit", clicked = lambda: self.submit_clicked())
+        # submit_button.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+
+        self.setTabText(1, "Advanced")
+        self.advanced.setLayout(form_layout)
+
+    def add_checked_file(self):
+        self.tabs.addTab(CheckFile(), "File " + str(self.tabs.count() + 1))
+        self.tabs.setCurrentIndex(self.tabs.currentIndex() + 1)
+
+        # group_lay.insertWidget(group_lay.count() - 1, CheckFile(group_lay.count()))
+
+    def change_tab_text(self, text):
+        self.tabs.setTabText(self.tabs.currentIndex(), text)
+
+    def submit_form(self):
+        files = {}
+
+        for index in range(self.tabs.count()):
+            widget = self.tabs.widget(index)
+            key, val = widget.get_data()
+            files[key] = val
+
+        full_data = {"name": self.assignment_name.text(),
+                     "break": self.break_fail.isChecked(),
+                     "fastfail": self.fast_fail.isChecked(),
+                     "indent": int(self.indent_size.text()),
+                     "idcommand": "echo $TRAVIS_REPO_SLUG",
+                     "version": self.grader_version.text(),
+                     "executables": "cat, bash",
+                     "startup": self.startup_script_text.text(),
+                     "reflection": "./",
+                     "files": files
+                     }
+
+        print("Form Submitted!")
+        print(full_data)

--- a/src/gui/form.py
+++ b/src/gui/form.py
@@ -1,14 +1,22 @@
-from PyQt5 import QtGui
-from PyQt5.QtCore import *
-from PyQt5.QtGui import *
-from PyQt5.QtWidgets import *
+"""Form that makes up the configuration GUI"""
+from PyQt5.QtWidgets import QTabWidget, \
+    QWidget, QFormLayout, \
+    QCheckBox, QLineEdit, \
+    QVBoxLayout, QPushButton, \
+    QSpinBox, QHBoxLayout, QPlainTextEdit
+from src.gui.check_file import CheckFile
 
-from gui.check_file import CheckFile
-
+# pylint: disable=R0902
+# pylint: disable=W0108
+# Disabling R0902 because this is a main class. PyQt5 *requires* this type of code.
+# Could split this into multiple classes if REALLY needed but that can wait until later.
+# Also disabling W0108 because the lambda is necessary.
 
 class Form(QTabWidget):
+    """Main form class, contains basic and advanced tabs."""
     def __init__(self, parent=None):
-        super(QTabWidget, self).__init__(parent)
+        """Init the form. Create the two tabs and populate them with widgets."""
+        super().__init__(parent)
 
         # Create tabs
         self.basic = QWidget()
@@ -21,6 +29,7 @@ class Form(QTabWidget):
         self.advanced_tab()
 
     def basic_tab(self):
+        """Creates a new form and populates it with the widgets for basic configuration"""
         # Create a QFormLayout instance
         form_layout = QFormLayout()
 
@@ -44,11 +53,12 @@ class Form(QTabWidget):
 
         self.tabs = QTabWidget()
         self.tabs.setTabsClosable(True)
-        self.tabs.tabCloseRequested.connect(lambda index: self.tabs.removeTab(index))
+        self.tabs.tabCloseRequested.connect(self.tabs.removeTab)
 
         # Checked Files Controls
         # Create add file button
-        add_file_button = QPushButton("Add New Checked File", clicked=lambda: self.add_checked_file())
+        add_file_button = QPushButton(
+            "Add New Checked File", clicked=lambda: self.add_checked_file())
 
         # Add button to layout
         group_lay.addWidget(add_file_button)
@@ -61,6 +71,7 @@ class Form(QTabWidget):
         self.basic.setLayout(form_layout)
 
     def advanced_tab(self):
+        """Creates the form for the advanced tab and populates it with the required widgets."""
         # Create a QFormLayout instance
         form_layout = QFormLayout()
 
@@ -79,8 +90,9 @@ class Form(QTabWidget):
         self.lay = QHBoxLayout()
         self.startup_script_text = QLineEdit()
         self.startup_script_button = QPushButton("Open",
-                                                 clicked=lambda: self.get_path_from_file(self.startup_script_text,
-                                                                                         self.startup_script_button))
+                                                 clicked=lambda: self.get_path_from_file(
+                                                     self.startup_script_text,
+                                                     self.startup_script_button))
 
         # connect button to file dialog
         # self.startup_script_button.clicked.connect()
@@ -100,15 +112,18 @@ class Form(QTabWidget):
         self.advanced.setLayout(form_layout)
 
     def add_checked_file(self):
+        """Creates a new CheckFile and adds it to the basic config's file tabs."""
         self.tabs.addTab(CheckFile(), "File " + str(self.tabs.count() + 1))
         self.tabs.setCurrentIndex(self.tabs.currentIndex() + 1)
 
         # group_lay.insertWidget(group_lay.count() - 1, CheckFile(group_lay.count()))
 
     def change_tab_text(self, text):
+        """Changes the current tab's text."""
         self.tabs.setTabText(self.tabs.currentIndex(), text)
 
     def submit_form(self):
+        """Submits the data from both the basic and advanced tabs."""
         files = {}
 
         for index in range(self.tabs.count()):

--- a/src/gui/form.py
+++ b/src/gui/form.py
@@ -129,4 +129,5 @@ class Form(QTabWidget):
                      }
 
         print("Form Submitted!")
-        print(full_data)
+        # print(full_data)
+        return full_data

--- a/src/gui/homepage.py
+++ b/src/gui/homepage.py
@@ -1,0 +1,42 @@
+from PyQt5 import QtGui
+from PyQt5.QtCore import *
+from PyQt5.QtGui import *
+from PyQt5.QtWidgets import *
+from gui.form import Form
+
+
+class Homepage(QMainWindow):
+    def __init__(self, parent=None):
+        super(QMainWindow, self).__init__(parent)
+        self.setWindowTitle("New Configuration")
+
+        # Create Central Widget
+        main_win = QWidget()
+
+        # Create Layout
+        lay = QVBoxLayout()
+
+        # Create top label
+        top_label = QLabel("New Configuration File", alignment=Qt.AlignHCenter)
+
+        # Create Form
+        form = Form()
+
+        # Create Submit Button
+        submit_button = QPushButton("Submit", clicked=lambda: self.submit_form(form))
+
+        # Add widgets
+        lay.addWidget(top_label)
+        lay.addWidget(form)
+        lay.addWidget(submit_button)
+        lay.setAlignment(submit_button, Qt.AlignRight)
+        lay.addStretch()
+
+        # Set Layout
+        main_win.setLayout(lay)
+
+        # Set central widget
+        self.setCentralWidget(main_win)
+
+    def submit_form(self, form):
+        form.submit_form()

--- a/src/gui/homepage.py
+++ b/src/gui/homepage.py
@@ -6,10 +6,11 @@ from gui.form import Form
 
 
 class Homepage(QMainWindow):
-    def __init__(self, parent=None):
+    def __init__(self, owner=None, parent=None):
         super(QMainWindow, self).__init__(parent)
         self.setWindowTitle("New Configuration")
 
+        self.owner = owner
         # Create Central Widget
         main_win = QWidget()
 
@@ -39,4 +40,6 @@ class Homepage(QMainWindow):
         self.setCentralWidget(main_win)
 
     def submit_form(self, form):
-        form.submit_form()
+        data = form.submit_form()
+        self.owner.data = data
+        self.close()

--- a/src/gui/homepage.py
+++ b/src/gui/homepage.py
@@ -1,13 +1,15 @@
-from PyQt5 import QtGui
-from PyQt5.QtCore import *
-from PyQt5.QtGui import *
-from PyQt5.QtWidgets import *
-from gui.form import Form
+"""Main page for the PyQT app"""
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QMainWindow, QWidget, QVBoxLayout, QLabel, QPushButton
+from src.gui.form import Form
 
 
 class Homepage(QMainWindow):
+    """Custom QMainWindow object"""
     def __init__(self, owner=None, parent=None):
-        super(QMainWindow, self).__init__(parent)
+        """Init the widget, populate it with the configuration form"""
+        super().__init__(parent)
         self.setWindowTitle("New Configuration")
 
         self.owner = owner
@@ -40,6 +42,7 @@ class Homepage(QMainWindow):
         self.setCentralWidget(main_win)
 
     def submit_form(self, form):
+        """Gathers data from the form and closes the application"""
         data = form.submit_form()
         self.owner.data = data
         self.close()

--- a/src/gui_main.py
+++ b/src/gui_main.py
@@ -1,5 +1,7 @@
 """A GUI to easily create GatorYAML configuration dictionaries"""
 import sys
+
+from PyQt5.QtCore import QCoreApplication
 from PyQt5.QtWidgets import QApplication
 
 from src.gui.homepage import Homepage
@@ -37,6 +39,8 @@ class Gui:
 
         if not test:
             self.app.exec_()
+        else:
+            QCoreApplication.quit()
 
     def close_window(self):
         """Closes the window. Added to appease lord PyLint"""
@@ -45,7 +49,6 @@ class Gui:
     def get_data(self):
         """Returns submitted form data"""
         return self.data
-
 
 # gui = Gui()
 # print(type(gui))

--- a/src/gui_main.py
+++ b/src/gui_main.py
@@ -1,17 +1,18 @@
+"""A GUI to easily create GatorYAML configuration dictionaries"""
 import sys
-from PyQt5 import QtGui
-from PyQt5.QtCore import *
-from PyQt5.QtGui import *
-from PyQt5.QtWidgets import *
+from PyQt5.QtWidgets import QApplication
 
-from gui.homepage import Homepage
+from src.gui.homepage import Homepage
 
 
 # from Form import Form
 # from Homepage import Homepage
 
 class Gui:
+    """Main GUI object"""
+
     def __init__(self):
+        """Initializes PyQT application"""
         # Create App
         self.app = QApplication(sys.argv)
 
@@ -29,14 +30,20 @@ class Gui:
         self.data = None
 
         # Show Window
-        win = Homepage(owner=self)
-        win.setGeometry(400, 400, 400, 300)
+        self.win = Homepage(owner=self)
+        self.win.setGeometry(400, 400, 400, 300)
 
-        win.show()
+        self.win.show()
         self.app.exec_()
 
+    def close_window(self):
+        """Closes the window. Added to appease lord PyLint"""
+        self.win.close()
+
     def get_data(self):
+        """Returns submitted form data"""
         return self.data
 
-gui = Gui()
-print(gui.get_data())
+
+# gui = Gui()
+# print(type(gui))

--- a/src/gui_main.py
+++ b/src/gui_main.py
@@ -11,7 +11,7 @@ from src.gui.homepage import Homepage
 class Gui:
     """Main GUI object"""
 
-    def __init__(self):
+    def __init__(self, test=False):
         """Initializes PyQT application"""
         # Create App
         self.app = QApplication(sys.argv)
@@ -34,7 +34,9 @@ class Gui:
         self.win.setGeometry(400, 400, 400, 300)
 
         self.win.show()
-        self.app.exec_()
+
+        if not test:
+            self.app.exec_()
 
     def close_window(self):
         """Closes the window. Added to appease lord PyLint"""

--- a/src/gui_main.py
+++ b/src/gui_main.py
@@ -13,7 +13,7 @@ from src.gui.homepage import Homepage
 class Gui:
     """Main GUI object"""
 
-    def __init__(self, test=False):
+    def __init__(self):
         """Initializes PyQT application"""
         # Create App
         self.app = QApplication(sys.argv)
@@ -37,10 +37,8 @@ class Gui:
 
         self.win.show()
 
-        if not test:
-            self.app.exec_()
-        else:
-            QCoreApplication.quit()
+        self.app.exec_()
+
 
     def close_window(self):
         """Closes the window. Added to appease lord PyLint"""

--- a/src/gui_main.py
+++ b/src/gui_main.py
@@ -13,7 +13,7 @@ from gui.homepage import Homepage
 class Gui:
     def __init__(self):
         # Create App
-        app = QApplication(sys.argv)
+        self.app = QApplication(sys.argv)
 
         # Open the qss styles file and read
         # with open('./style.qss', 'r') as f:
@@ -26,12 +26,17 @@ class Gui:
         # Make it look not as bad...
         # app.setStyle()
 
+        self.data = None
+
         # Show Window
-        win = Homepage()
+        win = Homepage(owner=self)
         win.setGeometry(400, 400, 400, 300)
 
         win.show()
-        sys.exit(app.exec_())
+        self.app.exec_()
 
+    def get_data(self):
+        return self.data
 
 gui = Gui()
+print(gui.get_data())

--- a/src/gui_main.py
+++ b/src/gui_main.py
@@ -1,7 +1,6 @@
 """A GUI to easily create GatorYAML configuration dictionaries"""
 import sys
 
-from PyQt5.QtCore import QCoreApplication
 from PyQt5.QtWidgets import QApplication
 
 from src.gui.homepage import Homepage

--- a/src/gui_main.py
+++ b/src/gui_main.py
@@ -1,0 +1,37 @@
+import sys
+from PyQt5 import QtGui
+from PyQt5.QtCore import *
+from PyQt5.QtGui import *
+from PyQt5.QtWidgets import *
+
+from gui.homepage import Homepage
+
+
+# from Form import Form
+# from Homepage import Homepage
+
+class Gui:
+    def __init__(self):
+        # Create App
+        app = QApplication(sys.argv)
+
+        # Open the qss styles file and read
+        # with open('./style.qss', 'r') as f:
+        #     style = f.read()
+        #
+        #     # Set the stylesheet of the application
+        #     app.setStyleSheet(style)
+        # print(QStyleFactory.keys())
+
+        # Make it look not as bad...
+        # app.setStyle()
+
+        # Show Window
+        win = Homepage()
+        win.setGeometry(400, 400, 400, 300)
+
+        win.show()
+        sys.exit(app.exec_())
+
+
+gui = Gui()

--- a/tests/test_gui_main.py
+++ b/tests/test_gui_main.py
@@ -1,16 +1,19 @@
 """This module tests that the GUI opens"""
 
 from src.gui_main import Gui
+from src.gui.homepage import Homepage
 from src.gui.check_file import CheckFile
 
 
-def test_gui():
+def test_homepage(qtbot):
     """Check that the gui opens"""
-    gui = Gui(test=True)
-    assert isinstance(gui, Gui)
+    application = Homepage()
+    qtbot.addWidget(application)
+    assert isinstance(application, Homepage)
 
 
-def test_checkfile():
+def test_checkfile(qtbot):
     """Check that CheckFile is actually a CheckFile"""
     check = CheckFile()
+    qtbot.addWidget(check)
     assert isinstance(check, CheckFile)

--- a/tests/test_gui_main.py
+++ b/tests/test_gui_main.py
@@ -6,7 +6,7 @@ from src.gui.check_file import CheckFile
 
 def test_gui():
     """Check that the gui opens"""
-    gui = Gui()
+    gui = Gui(test=True)
     assert isinstance(gui, Gui)
 
 

--- a/tests/test_gui_main.py
+++ b/tests/test_gui_main.py
@@ -1,6 +1,5 @@
 """This module tests that the GUI opens"""
 
-from src.gui_main import Gui
 from src.gui.homepage import Homepage
 from src.gui.check_file import CheckFile
 

--- a/tests/test_gui_main.py
+++ b/tests/test_gui_main.py
@@ -1,0 +1,16 @@
+"""This module tests that the GUI opens"""
+
+from src.gui_main import Gui
+from src.gui.check_file import CheckFile
+
+
+def test_gui():
+    """Check that the gui opens"""
+    gui = Gui()
+    assert isinstance(gui, Gui)
+
+
+def test_checkfile():
+    """Check that CheckFile is actually a CheckFile"""
+    check = CheckFile()
+    assert isinstance(check, CheckFile)


### PR DESCRIPTION
# Feature GUI

## Description

To run just create a GUI object. Call `get_data()` after the GUI has closed to get the config data.

EX:
```Python
gui = Gui()
data = gui.get_data() # <---- This line does not run until the GUI closes.
# Do stuff with the data here.
```

Test cases implemented (though they could be improved with the addition of pytest-qt).

There are a few outstanding features left to add, such as some missing options however it should be almost all there.

Also doesn't have version lists for `gatorgrader` and `gatorgradle` from GitHub yet but that will be added with a separate feature.

**Note about linting:**
This will _not_ pass lint until .pylintrc is added to the repo/github actions as it whitelists the PyQt5 module. Pylint throws a fit because it doesn't check c++ packages by default.

### Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Documentation

## Contributors

- @ullrichd21 

## Reminder

All GitHub Actions should be in a passing state before any pull request is merged.
