### PR TITLE
Feature path split

### DIFF
--- a/src/gator_yaml.py
+++ b/src/gator_yaml.py
@@ -1,8 +1,10 @@
 """Converts dictionaries to GatorYAML"""
+import split_file_path
 
 
 class GatorYaml:
     """Main GatorYaml object"""
+
     def __init__(self, indent=4, spaces=4):
         """Init GatorYAML object. Takes optional arguments to change indent of files
         and how many spaces is considered a tab """
@@ -12,8 +14,15 @@ class GatorYaml:
         self.keywords = ["(pure)"]  # Any keywords to look for
         self.indents = indent  # set indent for file path
 
-    def dump(self, dic):
+    def dump(self, dic, paths=None):
         """Input dictionary is parsed. returns string of valid YAML"""
+
+        if paths is not None:
+            if isinstance(paths, dict):
+                dic["files"] = split_file_path(paths)
+            else:
+                raise Exception("Paths expected to be \"dict\", got " + str(type(paths)) + "!")
+
         self.enum_dict(dic)
 
         return self.output

--- a/src/gator_yaml.py
+++ b/src/gator_yaml.py
@@ -1,5 +1,5 @@
 """Converts dictionaries to GatorYAML"""
-import split_file_path
+from src.split_file_path import split_file_path
 
 
 class GatorYaml:

--- a/src/split_file_path.py
+++ b/src/split_file_path.py
@@ -1,6 +1,8 @@
 """Split file path module."""
-def split_file_path(paths):
-    """Convert files paths stored in a dic to nested dics."""
+
+
+def split_file_path(paths: list) -> dict:
+    """Convert files paths stored in a dict to nested dicts."""
     output = {}
     for key, value in paths.items():
         directories = key.split('/')


### PR DESCRIPTION
# Feature: Add split file path to GatorYAML

## Description

GatorYAML now has built in support for splitting file paths so you no longer need to use another tool.

Instructions:

Option 1 - manually use the split file path tool to split the files and add them as a key to the dictionary

Option 2 (this feature) - use `paths=` to give a dictionary of `{"path":["param line 1", "param line 2"]}` which will be appended to the given dictionary.

### Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Documentation

## Contributors

- @ullrichd21

## Reminder

All GitHub Actions should be in a passing state before any pull request is merged.
