### PR TITLE
Change Poetry ver to 1.1.12 in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Poetry
         run: |
           python -m pip install --upgrade pip
-          pip install poetry==1.2.* --pre
+          pip install poetry==1.1.12
       - name: Publish
         run: |
           poetry version ${GITHUB_REF##*/v}


### PR DESCRIPTION
# Change Poetry ver to 1.1.12 in publish.yml

## Description

Change the Poetry version in `publish.yml` to match the Poetry version used by Actions.

### Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Documentation

## Contributors

- @PaigeCD 

## Reminder

All GitHub Actions should be in a passing state before any pull request is merged.
