### PR TITLE
Feature/gen readme

### DIFF
--- a/gatorconfig/gator_config.py
+++ b/gatorconfig/gator_config.py
@@ -73,7 +73,8 @@ def readme_gen(gen_readme: bool):
                     "# " + default_name() + "\n" + "\n" +
                     "This is the repository containing the " + default_name() + " assignment."
                     + "\n" + "\n" + "## Using GatorGradle" + "\n" + "\n" +
-                    "This assignment utilizes [GatorGrader](https://github.com/GatorEducator/gatorgrader)"
+                    "This assignment utilizes " +
+                    "[GatorGrader](https://github.com/GatorEducator/gatorgrader)"
                     " in order to perform automated grading checks." +
                     " To grade your assignment, run the following command in your " +
                     "Docker container or environment containing Gradle:"

--- a/gatorconfig/gator_config.py
+++ b/gatorconfig/gator_config.py
@@ -66,12 +66,18 @@ def cli_input(
 
 def readme_gen(gen_readme: bool):
     """Generate basic README in current directory."""
-    if gen_readme == True:
+    if gen_readme is True:
         try:
-            with open("README2.md", "x") as file:
+            with open("README.md", "x", encoding="utf8") as file:
                 file.write(
                     "# " + default_name() + "\n" + "\n" +
                     "This is the repository containing the " + default_name() + " assignment."
+                    + "\n" + "\n" + "## Using GatorGradle" + "\n" + "\n" +
+                    "This assignment utilizes [GatorGrader](https://github.com/GatorEducator/gatorgrader)"
+                    " in order to perform automated grading checks." +
+                    " To grade your assignment, run the following command in your " +
+                    "Docker container or environment containing Gradle:"
+                    + "\n" + "\n" + "```" + "\n" + "gradle grade" + "\n" + "```" + "\n"
                 )
         except FileExistsError:
             print("Your repository already contains a README.md.")

--- a/gatorconfig/gator_config.py
+++ b/gatorconfig/gator_config.py
@@ -27,7 +27,6 @@ def cli_input(
     gen_readme: bool = typer.Option(False, help="Generates a README file"),
     file: List[str] = typer.Option([], help="""Enter singular file path, can be done
     multiple times"""),
-    #language: str = typer.Option(None),
     output_path: Path = typer.Option(Path.cwd(), help="Enter preferred output path"),
     indent: int = typer.Option(4, help="Enter preferred indent"),
     commit_count: int = typer.Option(5, help="Enter preferred minimum amount of commits")
@@ -53,7 +52,6 @@ def cli_input(
             "name": name,
             "break": brk,
             "fastfail": fastfail,
-            "readme": gen_readme,
             "indent": indent,
             "commits": commit_count,
         }
@@ -63,6 +61,20 @@ def cli_input(
         print(f"\"gatorgrader.yml\" already exists within {config_dir}")
     #print(files)
     actions_configuration.create_configuration_file('.github/workflows/grade.yml')
+    readme_gen(gen_readme)
+
+
+def readme_gen(gen_readme: bool):
+    """Generate basic README in current directory."""
+    if gen_readme == True:
+        try:
+            with open("README2.md", "x") as file:
+                file.write(
+                    "# " + default_name() + "\n" + "\n" +
+                    "This is the repository containing the " + default_name() + " assignment."
+                )
+        except FileExistsError:
+            print("Your repository already contains a README.md.")
 
 
 def output_file(yaml_string: str, output_path: Path):
@@ -76,6 +88,7 @@ def output_file(yaml_string: str, output_path: Path):
     pth.mkdir(exist_ok=True)
     (pth / 'gatorgrader.yml').open('w').write(yaml_string)
     print(f"Wrote file to: {pth}" + "/gatorgrader.yml")
+
 
 def get_checks(file: List[Path]) -> Dict:
     """Read in checks per file.

--- a/gatorconfig/gator_config.py
+++ b/gatorconfig/gator_config.py
@@ -61,14 +61,14 @@ def cli_input(
         print(f"\"gatorgrader.yml\" already exists within {config_dir}")
     #print(files)
     actions_configuration.create_configuration_file('.github/workflows/grade.yml')
-    readme_gen(gen_readme)
+    readme_gen(gen_readme, output_path)
 
 
-def readme_gen(gen_readme: bool):
+def readme_gen(gen_readme: bool, output_path: Path):
     """Generate basic README in current directory."""
     if gen_readme is True:
         try:
-            with open("README.md", "x", encoding="utf8") as file:
+            with open(Path(output_path / "README.md"), "x", encoding="utf8") as file:
                 file.write(
                     "# " + default_name() + "\n" + "\n" +
                     "This is the repository containing the " + default_name() + " assignment."

--- a/gatorconfig/gator_config.py
+++ b/gatorconfig/gator_config.py
@@ -76,7 +76,7 @@ def cli_input(
 
 def readme_gen(gen_readme: bool, output_path: Path):
     """Generate basic README in current directory."""
-    if gen_readme is True:
+    if gen_readme:
         try:
             with open(Path(output_path / "README.md"), "x", encoding="utf8") as file:
                 file.write(

--- a/tests/test_gator_config.py
+++ b/tests/test_gator_config.py
@@ -17,6 +17,7 @@ def test_cli_input(mocker, tmpdir):
             "Test",
             "--break",
             "--fastfail",
+            "--gen-readme",
             "--file",
             "Object 1",
             "--indent",
@@ -28,8 +29,10 @@ def test_cli_input(mocker, tmpdir):
             ])
     print("Test Output:", result.stdout)
     test_file = test_dir / "config" / "gatorgrader.yml"
+    test_readme = test_dir / "README.md"
     with mocker.patch('builtins.input', return_value=""):
         assert test_file.exists()
+        assert test_readme.exists()
     with open(test_file, encoding='utf-8') as fle:
         print(fle.read())
 


### PR DESCRIPTION
# Add ability to generate README

## Description

Add the readme_gen function which enable the use of the --gen-readme flag. As per the user story, this README file contains simple instructions on running GatorGradle.

### Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Documentation

## Contributors

- @PaigeCD 

## Reminder

All GitHub Actions should be in a passing state before any pull request is merged.
