### PR TITLE
Hotfix/gui bugs

### DIFF
--- a/gatorconfig/gui/check_file.py
+++ b/gatorconfig/gui/check_file.py
@@ -49,6 +49,7 @@ class CheckFile(QWidget):
         """Opens a file dialog to select a new file.
         Sets self.file to the file name and sets the tab text."""
         self.file = QFileDialog.getOpenFileName(self, 'OpenFile')[0]
+        self.file = os.path.relpath(self.file, os.curdir)
         target_text.setText(self.file)
         tabs = self.parentWidget().parentWidget()
         tabs.setTabText(tabs.currentIndex(), os.path.basename(self.file))

--- a/gatorconfig/gui/check_file.py
+++ b/gatorconfig/gui/check_file.py
@@ -1,5 +1,5 @@
 """Checked File widgets"""
-# pylint: disable=E0611
+# pylint: disable=no-name-in-module
 # RC file is not working.
 import os
 from PyQt6.QtWidgets import QWidget, \
@@ -24,7 +24,7 @@ class CheckFile(QWidget):
         lay = QHBoxLayout()
         self.check_label = QLabel("File ")
         self.path_text = QLineEdit()
-        self.path_button = QPushButton("Open",
+        self.path_button = QPushButton("Browse...",
                                        clicked=lambda: self.get_path_from_file(self.path_text))
         self.file_params = QPlainTextEdit()
 

--- a/gatorconfig/gui/cwidgets.py
+++ b/gatorconfig/gui/cwidgets.py
@@ -18,10 +18,9 @@ class CFilePicker(QWidget):
         self.line = QLineEdit()
         if default is not None:
             self.line.setText(default)
-        self.button = QPushButton("Open",
+        self.button = QPushButton("Browse...",
                                   clicked=lambda: self.line.setText(
                                       QFileDialog.getOpenFileName(self, 'OpenFile')[0]))
-        # self.button.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         hbox = QHBoxLayout()
         hbox.addWidget(self.line)
         hbox.addWidget(self.button)

--- a/gatorconfig/gui/cwidgets.py
+++ b/gatorconfig/gui/cwidgets.py
@@ -1,6 +1,8 @@
 """Custom PyQt Widgets"""
 # pylint: disable=no-name-in-module
 # RC file is not working.
+import os
+
 from PyQt6.QtWidgets import QWidget, QLineEdit, QPushButton, QFileDialog, QHBoxLayout
 
 
@@ -18,7 +20,7 @@ class CFilePicker(QWidget):
             self.line.setText(default)
         self.button = QPushButton("Open",
                                   clicked=lambda: self.line.setText(
-                                      QFileDialog().getExistingDirectory()))
+                                      QFileDialog.getOpenFileName(self, 'OpenFile')[0]))
         # self.button.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         hbox = QHBoxLayout()
         hbox.addWidget(self.line)
@@ -27,7 +29,7 @@ class CFilePicker(QWidget):
 
     def set_textbox_text(self, text):
         """Set the textbox text"""
-        self.line.setText(text)
+        self.line.setText(os.path.relpath(text))
 
     def get_file_path(self):
         """Return the file path from the text box"""

--- a/gatorconfig/gui/form.py
+++ b/gatorconfig/gui/form.py
@@ -201,11 +201,11 @@ class Form(QTabWidget):
         txt = self.idcommand.text()
         if txt != "":
             data["header"]["idcommand"] = txt
-            return data
+        return data
 
     def insert_executables(self, data):
         """Returns full_data header with added executables if the user specified any"""
         txt = self.executables.text()
         if txt != "":
             data["header"]["executables"] = txt
-            return data
+        return data

--- a/gatorconfig/gui/form.py
+++ b/gatorconfig/gui/form.py
@@ -182,8 +182,8 @@ class Form(QTabWidget):
                         "body": files
                      }
 
-        self.insert_idcommand(data)
-        self.insert_executables(data)
+        full_data = self.insert_idcommand(full_data)
+        full_data = self.insert_executables(full_data)
 
         print("Form Submitted!")
         return full_data
@@ -197,13 +197,15 @@ class Form(QTabWidget):
         return self.grader_version.text()
 
     def insert_idcommand(self, data):
+        """Returns full_data header with added idcommand if the user specified one."""
         txt = self.idcommand.text()
         if txt != "":
             data["header"]["idcommand"] = txt
             return data
 
     def insert_executables(self, data):
+        """Returns full_data header with added executables if the user specified any"""
         txt = self.executables.text()
         if txt != "":
-            data["header"]["idcommand"] = txt
+            data["header"]["executables"] = txt
             return data

--- a/gatorconfig/gui/form.py
+++ b/gatorconfig/gui/form.py
@@ -175,14 +175,15 @@ class Form(QTabWidget):
                             "break": self.break_fail.isChecked(),
                             "fastfail": self.fast_fail.isChecked(),
                             "indent": int(self.indent_size.text()),
-                            "idcommand": "",
                             "version": self.get_grader_version(),
-                            "executables": "",
                             "startup": self.startup_script_text.text(),
                             "reflection": ""
                         },
                         "body": files
                      }
+
+        self.insert_idcommand(data)
+        self.insert_executables(data)
 
         print("Form Submitted!")
         return full_data
@@ -194,3 +195,15 @@ class Form(QTabWidget):
                 return "master"
             return self.grader_version.currentText()
         return self.grader_version.text()
+
+    def insert_idcommand(self, data):
+        txt = self.idcommand.text()
+        if txt != "":
+            data["header"]["idcommand"] = txt
+            return data
+
+    def insert_executables(self, data):
+        txt = self.executables.text()
+        if txt != "":
+            data["header"]["idcommand"] = txt
+            return data

--- a/gatorconfig/gui/form.py
+++ b/gatorconfig/gui/form.py
@@ -91,7 +91,6 @@ class Form(QTabWidget):
         # Add button to layout
         group_lay.addWidget(add_file_button)
 
-        # group.setLayout(group_lay)
         form_layout.addRow(self.tabs)
         form_layout.addRow(group_lay)
 
@@ -117,7 +116,7 @@ class Form(QTabWidget):
         # Hbox Layout
         self.lay = QHBoxLayout()
         self.startup_script_text = QLineEdit()
-        self.startup_script_button = QPushButton("Open",
+        self.startup_script_button = QPushButton("Browse...",
                                                  clicked=lambda: self.get_path_from_file(
                                                      self.startup_script_text))
 
@@ -137,9 +136,6 @@ class Form(QTabWidget):
 
         self.description_input2 = QPlainTextEdit()
 
-        # submit_button = QPushButton("Submit", clicked = lambda: self.submit_clicked())
-        # submit_button.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
-
         self.setTabText(1, "Advanced")
         self.advanced.setLayout(form_layout)
 
@@ -147,8 +143,6 @@ class Form(QTabWidget):
         """Creates a new CheckFile and adds it to the basic config's file tabs."""
         self.tabs.addTab(CheckFile(), "File " + str(self.tabs.count() + 1))
         self.tabs.setCurrentIndex(self.tabs.currentIndex() + 1)
-
-        # group_lay.insertWidget(group_lay.count() - 1, CheckFile(group_lay.count()))
 
     def get_path_from_file(self, target_text):
         """Opens a file dialog to select a new file.

--- a/gatorconfig/gui_main.py
+++ b/gatorconfig/gui_main.py
@@ -52,3 +52,6 @@ class Gui:
     def get_data(self):
         """Returns submitted form data"""
         return self.data["header"], self.data["body"]
+
+gui = Gui()
+print(gui.get_data())

--- a/gatorconfig/gui_main.py
+++ b/gatorconfig/gui_main.py
@@ -52,6 +52,3 @@ class Gui:
     def get_data(self):
         """Returns submitted form data"""
         return self.data["header"], self.data["body"]
-
-gui = Gui()
-print(gui.get_data())

--- a/poetry.lock
+++ b/poetry.lock
@@ -97,7 +97,7 @@ python-versions = "*"
 
 [[package]]
 name = "gatoryaml"
-version = "1.0.0"
+version = "1.0.1"
 description = "Custom YAML-like generator for GatorGrader config files."
 category = "main"
 optional = false
@@ -635,8 +635,8 @@ easyprocess = [
     {file = "EasyProcess-1.1.tar.gz", hash = "sha256:885898302a57aab948973e8b5d32a4229392b9fb2d986ab1d4ffd590e5ba90ec"},
 ]
 gatoryaml = [
-    {file = "GatorYaml-1.0.0-py3-none-any.whl", hash = "sha256:0a18c08eddee4fb99cd1cfc2b14179166f384f64a73d75f7c8d5ac822fa2ef36"},
-    {file = "GatorYaml-1.0.0.tar.gz", hash = "sha256:315b191f62f5ce8c657724a806659f61e9e6270a6a312390041fadbb51ad1fe9"},
+    {file = "GatorYaml-1.0.1-py3-none-any.whl", hash = "sha256:30618dd07a03011883d71af8068d73bf7d88f424cccaab4e81c217fbbf817f03"},
+    {file = "GatorYaml-1.0.1.tar.gz", hash = "sha256:5f5ab83728f0a2a1386ea5f2b0076d79df10a22e436eed8cdcee4322cedfab81"},
 ]
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},


### PR DESCRIPTION
<!-- TODO: Replace the title below -->
# Hotfix: Gui Bugs

## Description

<!-- TODO: Write a description of the proposed changes -->

`In the GUI, you cannot select a file (only folders) in Reflection's Open button-triggered file chooser.`
This is now resolved.

`When using the GUI, any checks added end up using the full absolute path to the file in gatorgrader.yml, instead of a path relative to the root of the assignment.`
This is now be resolved.

`When a file is in the root directory of the assignment and is passed as an argument to --file, an empty : is added in the gatorgrader.yml output`
This is now resolved.


### Type of Change

<!-- TODO: Fill in the brackets with an `x` next to all types that apply to the proposed changes -->
- [ ] Feature
- [x] Bug fix
- [ ] Documentation

## Contributors

<!-- TODO: Add your GitHub username below and the GitHub usernames of all other contributors to the proposed changes -->
- @ullrichd21

## Reminder

All GitHub Actions should be in a passing state before any pull request is merged.
